### PR TITLE
Add boost field to Match/MatchPhrase/MatchPhrasePrefix

### DIFF
--- a/Sources/Elasticsearch/Search/Query/Match.swift
+++ b/Sources/Elasticsearch/Search/Query/Match.swift
@@ -23,35 +23,40 @@ public struct Match: QueryElement {
     let value: String
     let `operator`: Operator?
     let fuzziness: Int?
+    let boost: Decimal?
 
     public init(
         field: String,
         value: String,
         operator: Operator? = nil,
-        fuzziness: Int? = nil
+        fuzziness: Int? = nil,
+        boost: Decimal? = nil
     ) {
         self.field = field
         self.value = value
         self.operator = `operator`
         self.fuzziness = fuzziness
+        self.boost = boost
     }
 
     private struct Inner: Codable {
         let value: String
         let `operator`: Operator?
         let fuzziness: Int?
+        let boost: Decimal?
 
         enum CodingKeys: String, CodingKey {
             case value = "query"
             case `operator`
             case fuzziness
+            case boost
         }
     }
 
     /// :nodoc:
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: DynamicKey.self)
-        let inner = Match.Inner(value: value, operator: `operator`, fuzziness: fuzziness)
+        let inner = Match.Inner(value: value, operator: `operator`, fuzziness: fuzziness, boost: boost)
 
         try container.encode(inner, forKey: DynamicKey(stringValue: field)!)
     }
@@ -67,6 +72,7 @@ public struct Match: QueryElement {
         self.value = inner.value
         self.`operator` = inner.`operator`
         self.fuzziness = inner.fuzziness
+        self.boost = inner.boost
     }
 }
 

--- a/Sources/Elasticsearch/Search/Query/MatchPhrase.swift
+++ b/Sources/Elasticsearch/Search/Query/MatchPhrase.swift
@@ -12,23 +12,26 @@ public struct MatchPhrase: QueryElement {
     let field: String
     let query: String
     let analyzer: String?
+    let boost: Decimal?
 
-    public init(field: String, query: String, analyzer: String? = nil) {
+    public init(field: String, query: String, analyzer: String? = nil, boost: Decimal? = nil) {
         self.field = field
         self.query = query
         self.analyzer = analyzer
+        self.boost = boost
     }
     
     private struct Inner: Codable {
         let query: String
         let analyzer: String?
+        let boost: Decimal?
     }
 
     /// :nodoc:
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: DynamicKey.self)
         
-        let inner = MatchPhrase.Inner(query: self.query, analyzer: self.analyzer)
+        let inner = MatchPhrase.Inner(query: self.query, analyzer: self.analyzer, boost: self.boost)
         try container.encode(inner, forKey: DynamicKey(stringValue: field)!)
     }
     
@@ -41,5 +44,6 @@ public struct MatchPhrase: QueryElement {
         let inner = try container.decode(MatchPhrase.Inner.self, forKey: key!)
         self.query = inner.query
         self.analyzer = inner.analyzer
+        self.boost = inner.boost
     }
 }

--- a/Sources/Elasticsearch/Search/Query/MatchPhrasePrefix.swift
+++ b/Sources/Elasticsearch/Search/Query/MatchPhrasePrefix.swift
@@ -13,25 +13,28 @@ public struct MatchPhrasePrefix: QueryElement {
     let query: String
     let analyzer: String?
     let maxExpansions: Int?
+    let boost: Decimal?
     
-    public init(field: String, query: String, analyzer: String?, maxExpansions: Int?) {
+    public init(field: String, query: String, analyzer: String? = nil, maxExpansions: Int? = nil, boost: Decimal? = nil) {
         self.field = field
         self.query = query
         self.analyzer = analyzer
         self.maxExpansions = maxExpansions
+        self.boost = boost
     }
     
     private struct Inner: Codable {
         let query: String
         let analyzer: String?
         let maxExpansions: Int?
+        let boost: Decimal?
     }
     
     /// :nodoc:
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: DynamicKey.self)
         
-        let inner = MatchPhrasePrefix.Inner(query: self.query, analyzer: self.analyzer, maxExpansions: self.maxExpansions)
+        let inner = MatchPhrasePrefix.Inner(query: self.query, analyzer: self.analyzer, maxExpansions: self.maxExpansions, boost: self.boost)
         try container.encode(inner, forKey: DynamicKey(stringValue: field)!)
     }
     
@@ -45,5 +48,6 @@ public struct MatchPhrasePrefix: QueryElement {
         self.query = inner.query
         self.analyzer = inner.analyzer
         self.maxExpansions = inner.maxExpansions
+        self.boost = inner.boost
     }
 }


### PR DESCRIPTION
This is not documented very well (e.g. I would expect it to be documented [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-query.html)), but you can provide a boost parameter to `match`, `match_phrase` and `match_phrase_prefix` queries: https://www.elastic.co/guide/en/elasticsearch/reference/6.3/mapping-boost.html

Additionally I have added default parameters to their initializers.