### PR TITLE
Conform to DatabaseLogger

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,13 @@ databases.add(database: es, as: .elasticsearch)
 services.register(databases)
 ```
 
+#### Enable Logging
+```swift
+var databases = DatabasesConfig()
+databases.enableLogging(on: .elasticsearch)
+services.register(databases)
+```
+
 ### Simple search example
 
 ```

--- a/Sources/Elasticsearch/Client/ElasticsearchClient.swift
+++ b/Sources/Elasticsearch/Client/ElasticsearchClient.swift
@@ -12,7 +12,10 @@ public final class ElasticsearchClient: DatabaseConnection, BasicWorker {
     
     /// See `DatabaseConnection`.
     public var isClosed: Bool
-    
+
+    /// If non-nil, will log requests/reponses.
+    public var logger: DatabaseLogger?
+
     /// See `Extendable`.
     public var extend: Extend
     
@@ -116,8 +119,7 @@ public final class ElasticsearchClient: DatabaseConnection, BasicWorker {
             }
         }
 
-        // TODO should be debug logged
-        print(request.description)
+        logger?.log(query: request.description)
         
         return self.esConnection.send(request).map(to: Data.self) { response in
             if response.body.data == nil {
@@ -135,7 +137,7 @@ public final class ElasticsearchClient: DatabaseConnection, BasicWorker {
             
             // TODO should be debug logged
             let bodyString = String(data: response.body.data!, encoding: String.Encoding.utf8) as String?
-            print(bodyString!)
+            self.logger?.log(query: bodyString ?? "")
             
             return response.body.data!
         }

--- a/Sources/Elasticsearch/Client/ElasticsearchLogger.swift
+++ b/Sources/Elasticsearch/Client/ElasticsearchLogger.swift
@@ -1,0 +1,13 @@
+import Async
+
+/// An Elasticsearch logger.
+public protocol ElasticsearchLogger {
+    /// Log the request/response.
+    func log(query: String)
+}
+
+extension DatabaseLogger: ElasticsearchLogger {
+    public func log(query: String) {
+        record(query: query, values: [])
+    }
+}

--- a/Sources/Elasticsearch/Database/ElasticsearchDatabase+LogSupporting.swift
+++ b/Sources/Elasticsearch/Database/ElasticsearchDatabase+LogSupporting.swift
@@ -1,0 +1,6 @@
+extension ElasticsearchDatabase: LogSupporting {
+    /// See `LogSupporting`.
+    public static func enableLogging(_ logger: DatabaseLogger, on conn: ElasticsearchDatabase.Connection) {
+        conn.logger = logger
+    }
+}

--- a/Tests/ElasticsearchTests/ElasticsearchTests.swift
+++ b/Tests/ElasticsearchTests/ElasticsearchTests.swift
@@ -45,7 +45,7 @@ final class ElasticsearchTests: XCTestCase {
             .property(key: "name", type: MapText())
             .property(key: "number", type: MapInteger())
             .alias(name: "testalias")
-            .settings(index: IndexSettings(shards: 3, replicas: 2))
+            .indexSettings(index: IndexSettings(shards: 3, replicas: 2))
             .add(metaKey: "Foo", metaValue: "Bar")
             .create().wait()
         
@@ -75,7 +75,7 @@ final class ElasticsearchTests: XCTestCase {
             .property(key: "name", type: MapText())
             .property(key: "number", type: MapInteger())
             .alias(name: "testalias")
-            .settings(index: IndexSettings(shards: 3, replicas: 2))
+            .indexSettings(index: IndexSettings(shards: 3, replicas: 2))
             .create().wait()
         
         var indexDoc: TestModel = TestModel(name: "bar", number: 26)
@@ -122,7 +122,7 @@ final class ElasticsearchTests: XCTestCase {
             .property(key: "name", type: MapText())
             .property(key: "number", type: MapInteger())
             .alias(name: "testalias")
-            .settings(index: IndexSettings(shards: 3, replicas: 2))
+            .indexSettings(index: IndexSettings(shards: 3, replicas: 2))
             .create().wait()
         
         var doc0: TestModel = TestModel(name: "foo", number: 26)


### PR DESCRIPTION
Now you can enable logging in `configure.swift`:

```swift
// Register the configured MySQL database to the database config.
    var databases = DatabasesConfig()
    databases.add(database: elasticSearch, as: .elasticsearch)
    databases.enableLogging(on: .elasticsearch)
    services.register(databases)
```

Apart from that this PR fixes 3 failing tests.