### PR TITLE
Added basic implementation of search order

### DIFF
--- a/Sources/Elasticsearch/Model/Response/SearchResponse.swift
+++ b/Sources/Elasticsearch/Model/Response/SearchResponse.swift
@@ -26,7 +26,7 @@ public struct SearchResponse<T: Decodable>: Decodable {
             public let index: String
             public let type: String
             public let id: String
-            public let score: Decimal
+            public let score: Decimal?
             public let source: T
             
             enum CodingKeys: String, CodingKey {
@@ -42,7 +42,7 @@ public struct SearchResponse<T: Decodable>: Decodable {
                 self.index = try container.decode(String.self, forKey: .index)
                 self.type = try container.decode(String.self, forKey: .type)
                 self.id = try container.decode(String.self, forKey: .id)
-                self.score = try container.decode(Decimal.self, forKey: .score)
+                self.score = try container.decodeIfPresent(Decimal.self, forKey: .score)
                 var source = try container.decode(T.self, forKey: .source)
                 if var settableIDSource = source as? SettableID {
                     settableIDSource.setID(self.id)

--- a/Sources/Elasticsearch/Model/Response/SearchResponse.swift
+++ b/Sources/Elasticsearch/Model/Response/SearchResponse.swift
@@ -26,7 +26,9 @@ public struct SearchResponse<T: Decodable>: Decodable {
             public let index: String
             public let type: String
             public let id: String
-            public let score: Decimal?
+            // The `score` property should be ideally optional; do this change
+            // next time it’s time to break things
+            public let score: Decimal
             public let source: T
             
             enum CodingKeys: String, CodingKey {
@@ -42,7 +44,9 @@ public struct SearchResponse<T: Decodable>: Decodable {
                 self.index = try container.decode(String.self, forKey: .index)
                 self.type = try container.decode(String.self, forKey: .type)
                 self.id = try container.decode(String.self, forKey: .id)
-                self.score = try container.decodeIfPresent(Decimal.self, forKey: .score)
+                // The forced default value on `score` should be ideally removed; do this change
+                // next time it’s time to break things
+                self.score = try container.decodeIfPresent(Decimal.self, forKey: .score) ?? 0
                 var source = try container.decode(T.self, forKey: .source)
                 if var settableIDSource = source as? SettableID {
                     settableIDSource.setID(self.id)

--- a/Sources/Elasticsearch/Search/Aggregation/Aggregation.swift
+++ b/Sources/Elasticsearch/Search/Aggregation/Aggregation.swift
@@ -7,12 +7,3 @@ public protocol Aggregation: Encodable {
     
     var name: String { get set }
 }
-
-/// Specify a direction for order
-///
-/// - asc: Ascending
-/// - desc: Descending
-public enum OrderDirection: String, Encodable {
-    case asc
-    case desc
-}

--- a/Sources/Elasticsearch/Search/Aggregation/Bucket Aggregations/TermsAggregation.swift
+++ b/Sources/Elasticsearch/Search/Aggregation/Bucket Aggregations/TermsAggregation.swift
@@ -19,7 +19,7 @@ public struct TermsAggregation: Aggregation {
     /// :nodoc:
     public let showTermDocCountError: Bool?
     /// :nodoc:
-    public let order: [String: OrderDirection]?
+    public let order: [String: SortOrder]?
     /// :nodoc:
     public let minDocCount: Int?
     /// :nodoc:
@@ -75,7 +75,7 @@ public struct TermsAggregation: Aggregation {
         field: String,
         size: Int? = nil,
         showTermDocCountError: Bool? = nil,
-        order: [String: OrderDirection]? = nil,
+        order: [String: SortOrder]? = nil,
         minDocCount: Int? = nil,
         script: Script? = nil,
         include: String? = nil,

--- a/Sources/Elasticsearch/Search/SearchContainer.swift
+++ b/Sources/Elasticsearch/Search/SearchContainer.swift
@@ -5,6 +5,7 @@ import Foundation
  */
 public struct SearchContainer: Encodable {
     public let query: Query?
+    public let sort: [Sort]?
     public let aggs: [Aggregation]?
     public let from: Int
     public let size: Int
@@ -12,6 +13,7 @@ public struct SearchContainer: Encodable {
 
     enum CodingKeys: String, CodingKey {
         case query
+        case sort
         case aggs
         case from
         case size
@@ -22,15 +24,30 @@ public struct SearchContainer: Encodable {
         self.init(query: nil, aggs: aggs)
     }
 
-    public init(_ query: Query, aggs: [Aggregation]? = nil, from: Int = 0, size: Int = 10, terminateAfter: Int? = nil) {
-        self.init(query: query, aggs: aggs, from: from, size: size)
+    public init(
+        _ query: Query,
+        sort: [Sort]? = nil,
+        aggs: [Aggregation]? = nil,
+        from: Int = 0,
+        size: Int = 10,
+        terminateAfter: Int? = nil
+    ) {
+        self.init(query: query, sort: sort, aggs: aggs, from: from, size: size)
     }
-        
-    private init(query: Query? = nil, aggs: [Aggregation]? = nil, from: Int = 0, size: Int = 10, terminateAfter: Int? = nil) {
+
+    private init(
+        query: Query? = nil,
+        sort: [Sort]? = nil,
+        aggs: [Aggregation]? = nil,
+        from: Int = 0,
+        size: Int = 10,
+        terminateAfter: Int? = nil
+    ) {
         self.query = query
+        self.sort = sort
         self.aggs = aggs
         self.from = from
-        self.size = query == nil ? 0: size
+        self.size = query == nil ? 0 : size
         self.terminateAfter = terminateAfter
     }
 
@@ -40,9 +57,8 @@ public struct SearchContainer: Encodable {
         try container.encode(from, forKey: .from)
         try container.encode(size, forKey: .size)
 
-        if query != nil {
-            try container.encode(query, forKey: .query)
-        }
+        try container.encodeIfPresent(query, forKey: .query)
+        try container.encodeIfPresent(sort, forKey: .sort)
 
         if aggs != nil && aggs!.count > 0 {
             var aggContainer = container.nestedContainer(keyedBy: DynamicKey.self, forKey: .aggs)

--- a/Sources/Elasticsearch/Search/Sort/Sort.swift
+++ b/Sources/Elasticsearch/Search/Sort/Sort.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+public struct Sort: Codable {
+    let key: String
+    let order: SortOrder
+
+    public init(_ key: String, _ order: SortOrder) {
+        self.key = key
+        self.order = order
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: DynamicKey.self)
+        let key = container.allKeys[0]
+        self.key = key.stringValue
+
+        let valuesContainer = try container.nestedContainer(keyedBy: NestedKeys.self, forKey: key)
+        self.order = try valuesContainer.decode(SortOrder.self, forKey: .order)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: DynamicKey.self)
+        var valuesContainer = container.nestedContainer(keyedBy: NestedKeys.self, forKey: DynamicKey(stringValue: key)!)
+
+        try valuesContainer.encode(order, forKey: .order)
+    }
+
+    enum NestedKeys: String, CodingKey {
+        case order
+    }
+}

--- a/Sources/Elasticsearch/Search/Sort/SortOrder.swift
+++ b/Sources/Elasticsearch/Search/Sort/SortOrder.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+public enum SortOrder: String, Codable {
+    case ascending = "asc"
+    case descending = "desc"
+}

--- a/Tests/ElasticsearchTests/ElasticsearchQueryCodableTests.swift
+++ b/Tests/ElasticsearchTests/ElasticsearchQueryCodableTests.swift
@@ -520,6 +520,7 @@ final class ElasticsearchQueryCodableTests: XCTestCase {
         ("testGeoPolygon_encodesInQueryCorrectly",  testGeoPolygon_encodesInQueryCorrectly),
 
         ("testSort_encodesInQueryCorrectly",        testSort_encodesInQueryCorrectly),
+        ("testSort_encodesInSearchContainerCorrectly", testSort_encodesInSearchContainerCorrectly),
 
         ("testLinuxTestSuiteIncludesAllTests",      testLinuxTestSuiteIncludesAllTests)
     ]

--- a/Tests/ElasticsearchTests/ElasticsearchQueryCodableTests.swift
+++ b/Tests/ElasticsearchTests/ElasticsearchQueryCodableTests.swift
@@ -9,89 +9,87 @@ final class ElasticsearchQueryCodableTests: XCTestCase {
         encoder = JSONEncoder()
         decoder = JSONDecoder()
     }
-    
-    
+
     func testAvgAggregation_encodesCorrectly() throws {
         let json = """
         {"aggs":{"foo":{"avg":{"field":"bar","missing":5}}},"size":0,"from":0}
         """
         let queryContainer = SearchContainer(aggs: [AvgAggregation(name: "foo", field: "bar", missing: 5)])
         let encoded = try encoder.encodeToString(queryContainer)
-        
+
         XCTAssertEqual(json, encoded)
     }
-    
+
     func testCardinalityAggregation_encodesCorrectly() throws {
         let json = """
         {"aggs":{"foo":{"cardinality":{"field":"bar"}}},"size":0,"from":0}
         """
         let queryContainer = SearchContainer(aggs: [CardinalityAggregation(name: "foo", field: "bar")])
         let encoded = try encoder.encodeToString(queryContainer)
-        
+
         XCTAssertEqual(json, encoded)
     }
-    
+
     func testExtendedStatsAggregation_encodesCorrectly() throws {
         let json = """
         {"aggs":{"foo":{"extended_stats":{"field":"bar"}}},"size":0,"from":0}
         """
         let queryContainer = SearchContainer(aggs: [ExtendedStatsAggregation(name: "foo", field: "bar")])
         let encoded = try encoder.encodeToString(queryContainer)
-        
+
         XCTAssertEqual(json, encoded)
     }
-    
+
     func testGeoBoundsAggregation_encodesCorrectly() throws {
         let json = """
         {"aggs":{"foo":{"geo_bounds":{"field":"bar"}}},"size":0,"from":0}
         """
         let queryContainer = SearchContainer(aggs: [GeoBoundsAggregation(name: "foo", field: "bar")])
         let encoded = try encoder.encodeToString(queryContainer)
-        
+
         XCTAssertEqual(json, encoded)
     }
-    
+
     func testGeoCentroidAggregation_encodesCorrectly() throws {
         let json = """
         {"aggs":{"foo":{"geo_centroid":{"field":"bar"}}},"size":0,"from":0}
         """
         let queryContainer = SearchContainer(aggs: [GeoCentroidAggregation(name: "foo", field: "bar")])
         let encoded = try encoder.encodeToString(queryContainer)
-        
+
         XCTAssertEqual(json, encoded)
     }
-    
+
     func testMaxAggregation_encodesCorrectly() throws {
         let json = """
         {"aggs":{"foo":{"max":{"field":"bar"}}},"size":0,"from":0}
         """
         let queryContainer = SearchContainer(aggs: [MaxAggregation(name: "foo", field: "bar")])
         let encoded = try encoder.encodeToString(queryContainer)
-        
+
         XCTAssertEqual(json, encoded)
     }
-    
+
     func testMinAggregation_encodesCorrectly() throws {
         let json = """
         {"aggs":{"foo":{"min":{"field":"bar"}}},"size":0,"from":0}
         """
         let queryContainer = SearchContainer(aggs: [MinAggregation(name: "foo", field: "bar")])
         let encoded = try encoder.encodeToString(queryContainer)
-        
+
         XCTAssertEqual(json, encoded)
     }
-    
+
     func testTermsAggregation_encodesCorrectly() throws {
         let json = """
         {"aggs":{"foo":{"terms":{"field":"bar"}}},"size":0,"from":0}
         """
         let queryContainer = SearchContainer(aggs: [TermsAggregation(name: "foo", field: "bar")])
         let encoded = try encoder.encodeToString(queryContainer)
-        
+
         XCTAssertEqual(json, encoded)
     }
-    
-    
+
     func testQueryContainer_encodesCorrectly() throws {
         let json = """
         {"size":10,"query":{"match":{"title":{"query":"Recipes with pasta or spaghetti","operator":"and"}}},"aggs":{"foo":{"avg":{"field":"bar","missing":5}}},"from":0}
@@ -100,10 +98,10 @@ final class ElasticsearchQueryCodableTests: XCTestCase {
         let query = Query(match)
         let queryContainer = SearchContainer(query, aggs: [AvgAggregation(name: "foo", field: "bar", missing: 5)])
         let encoded = try encoder.encodeToString(queryContainer)
-        
+
         XCTAssertEqual(json, encoded)
     }
-    
+
     func testMatchAll_encodesInQueryCorrectly() throws {
         let json = """
         {"match_all":{}}
@@ -111,7 +109,7 @@ final class ElasticsearchQueryCodableTests: XCTestCase {
         let matchAll = MatchAll()
         let query = Query(matchAll)
         let encoded = try encoder.encodeToString(query)
-        
+
         XCTAssertEqual(json, encoded)
 
         let toDecode = try encoder.encode(query)
@@ -119,7 +117,7 @@ final class ElasticsearchQueryCodableTests: XCTestCase {
         let encodedAgain = try encoder.encodeToString(decoded)
         XCTAssertEqual(json, encodedAgain)
     }
-    
+
     func testMatchNone_encodesInQueryCorrectly() throws {
         let json = """
         {"match_none":{}}
@@ -129,13 +127,13 @@ final class ElasticsearchQueryCodableTests: XCTestCase {
         let encoded = try encoder.encodeToString(query)
 
         XCTAssertEqual(json, encoded)
-        
+
         let toDecode = try encoder.encode(query)
         let decoded = try decoder.decode(Query.self, from: toDecode)
         let encodedAgain = try encoder.encodeToString(decoded)
         XCTAssertEqual(json, encodedAgain)
     }
-    
+
     func testMatch_encodesInQueryCorrectly() throws {
         let json = """
         {"match":{"title":{"query":"Recipes with pasta or spaghetti","operator":"and"}}}
@@ -143,15 +141,15 @@ final class ElasticsearchQueryCodableTests: XCTestCase {
         let match = Match(field: "title", value: "Recipes with pasta or spaghetti", operator: .and)
         let query = Query(match)
         let encoded = try encoder.encodeToString(query)
-        
+
         XCTAssertEqual(json, encoded)
-        
+
         let toDecode = try encoder.encode(query)
         let decoded = try decoder.decode(Query.self, from: toDecode)
         let encodedAgain = try encoder.encodeToString(decoded)
         XCTAssertEqual(json, encodedAgain)
     }
-    
+
     func testMatchPhrase_encodesInQueryCorrectly() throws {
         let json = """
         {"match_phrase":{"title":{"query":"puttanesca spaghetti"}}}
@@ -159,15 +157,15 @@ final class ElasticsearchQueryCodableTests: XCTestCase {
         let matchPhrase = MatchPhrase(field: "title", query: "puttanesca spaghetti")
         let query = Query(matchPhrase)
         let encoded = try encoder.encodeToString(query)
- 
+
         XCTAssertEqual(json, encoded)
-        
+
         let toDecode = try encoder.encode(query)
         let decoded = try decoder.decode(Query.self, from: toDecode)
         let encodedAgain = try encoder.encodeToString(decoded)
         XCTAssertEqual(json, encodedAgain)
     }
-    
+
     func testMultiMatch_encodesInQueryCorrectly() throws {
         let json = """
         {"multi_match":{"fields":["title","description"],"query":"pasta","type":"cross_fields","tie_breaker":0.3}}
@@ -177,13 +175,13 @@ final class ElasticsearchQueryCodableTests: XCTestCase {
         let encoded = try encoder.encodeToString(query)
 
         XCTAssertEqual(json, encoded)
-        
+
         let toDecode = try encoder.encode(query)
         let decoded = try decoder.decode(Query.self, from: toDecode)
         let encodedAgain = try encoder.encodeToString(decoded)
         XCTAssertEqual(json, encodedAgain)
     }
-    
+
     func testTerm_encodesInQueryCorrectly() throws {
         let json = """
         {"term":{"description":{"value":"drinking","boost":2}}}
@@ -191,15 +189,15 @@ final class ElasticsearchQueryCodableTests: XCTestCase {
         let term = Term(field: "description", value: "drinking", boost: 2.0)
         let query = Query(term)
         let encoded = try encoder.encodeToString(query)
-  
+
         XCTAssertEqual(json, encoded)
-        
+
         let toDecode = try encoder.encode(query)
         let decoded = try decoder.decode(Query.self, from: toDecode)
         let encodedAgain = try encoder.encodeToString(decoded)
         XCTAssertEqual(json, encodedAgain)
     }
-    
+
     func testTerms_encodesInQueryCorrectly() throws {
         let json = """
         {"terms":{"tags.keyword":["Soup","Cake"]}}
@@ -209,13 +207,13 @@ final class ElasticsearchQueryCodableTests: XCTestCase {
         let encoded = try encoder.encodeToString(query)
 
         XCTAssertEqual(json, encoded)
-        
+
         let toDecode = try encoder.encode(query)
         let decoded = try decoder.decode(Query.self, from: toDecode)
         let encodedAgain = try encoder.encodeToString(decoded)
         XCTAssertEqual(json, encodedAgain)
     }
-    
+
     func testRange_encodesInQueryCorrectly() throws {
         let json = """
         {"range":{"in_stock":{"gte":1,"lte":5}}}
@@ -225,13 +223,13 @@ final class ElasticsearchQueryCodableTests: XCTestCase {
         let encoded = try encoder.encodeToString(query)
 
         XCTAssertEqual(json, encoded)
-    
+
         let toDecode = try encoder.encode(query)
         let decoded = try decoder.decode(Query.self, from: toDecode)
         let encodedAgain = try encoder.encodeToString(decoded)
         XCTAssertEqual(json, encodedAgain)
     }
-    
+
     func testRange_encodesInQueryCorrectly_date() throws {
         let json = """
         {"range":{"created":{"gt":"01-01-2010","format":"dd-MM-yyyy","lt":"31-12-2010"}}}
@@ -239,15 +237,15 @@ final class ElasticsearchQueryCodableTests: XCTestCase {
         let range = Range(field: "created", greaterThan: "01-01-2010", lesserThan: "31-12-2010", format: "dd-MM-yyyy")
         let query = Query(range)
         let encoded = try encoder.encodeToString(query)
-        
+
         XCTAssertEqual(json, encoded)
-        
+
         let toDecode = try encoder.encode(query)
         let decoded = try decoder.decode(Query.self, from: toDecode)
         let encodedAgain = try encoder.encodeToString(decoded)
         XCTAssertEqual(json, encodedAgain)
     }
-    
+
     func testExists_encodesInQueryCorrectly() throws {
         let json = """
         {"exists":{"field":"tags"}}
@@ -255,15 +253,15 @@ final class ElasticsearchQueryCodableTests: XCTestCase {
         let exists = Exists(field: "tags")
         let query = Query(exists)
         let encoded = try encoder.encodeToString(query)
-        
+
         XCTAssertEqual(json, encoded)
-        
+
         let toDecode = try encoder.encode(query)
         let decoded = try decoder.decode(Query.self, from: toDecode)
         let encodedAgain = try encoder.encodeToString(decoded)
         XCTAssertEqual(json, encodedAgain)
     }
-    
+
     func testBool_encodesInQueryCorrectly() throws {
         let json = """
         {"bool":{"must":[{"match":{"title":{"query":"pasta"}}}]}}
@@ -273,15 +271,15 @@ final class ElasticsearchQueryCodableTests: XCTestCase {
         let bool = BoolQuery(must: [match])
         let query = Query(bool)
         let encoded = try encoder.encodeToString(query)
-        
+
         XCTAssertEqual(json, encoded)
-    
+
         let toDecode = try encoder.encode(query)
         let decoded = try decoder.decode(Query.self, from: toDecode)
         let encodedAgain = try encoder.encodeToString(decoded)
         XCTAssertEqual(json, encodedAgain)
     }
-    
+
     func testPrefix_encodesInQueryCorrectly() throws {
         let json = """
         {"prefix":{"tags.keyword":{"value":"Vege","boost":1}}}
@@ -289,15 +287,15 @@ final class ElasticsearchQueryCodableTests: XCTestCase {
         let prefix = Prefix(field: "tags.keyword", value: "Vege", boost: 1)
         let query = Query(prefix)
         let encoded = try encoder.encodeToString(query)
-        
+
         XCTAssertEqual(json, encoded)
-        
+
         let toDecode = try encoder.encode(query)
         let decoded = try decoder.decode(Query.self, from: toDecode)
         let encodedAgain = try encoder.encodeToString(decoded)
         XCTAssertEqual(json, encodedAgain)
     }
-    
+
     func testWildcard_encodesInQueryCorrectly() throws {
         let json = """
         {"wildcard":{"tags.keyword":{"value":"Veg*ble","boost":2}}}
@@ -305,16 +303,15 @@ final class ElasticsearchQueryCodableTests: XCTestCase {
         let wildcard = Wildcard(field: "tags.keyword", value: "Veg*ble", boost: 2)
         let query = Query(wildcard)
         let encoded = try encoder.encodeToString(query)
-        
-        
+
         XCTAssertEqual(json, encoded)
-        
+
         let toDecode = try encoder.encode(query)
         let decoded = try decoder.decode(Query.self, from: toDecode)
         let encodedAgain = try encoder.encodeToString(decoded)
         XCTAssertEqual(json, encodedAgain)
     }
-    
+
     func testRegexp_encodesInQueryCorrectly() throws {
         let json = """
         {"regexp":{"tags.keyword":{"value":"Veg[a-zA-Z]ble","boost":2.5}}}
@@ -322,15 +319,15 @@ final class ElasticsearchQueryCodableTests: XCTestCase {
         let regexp = Regexp(field: "tags.keyword", value: "Veg[a-zA-Z]ble", boost: 2.5)
         let query = Query(regexp)
         let encoded = try encoder.encodeToString(query)
-        
+
         XCTAssertEqual(json, encoded)
-        
+
         let toDecode = try encoder.encode(query)
         let decoded = try decoder.decode(Query.self, from: toDecode)
         let encodedAgain = try encoder.encodeToString(decoded)
         XCTAssertEqual(json, encodedAgain)
     }
-    
+
     func testFuzzy_encodesInQueryCorrectly() throws {
         let json = """
         {"fuzzy":{"name":{"value":"bolster","fuzziness":2}}}
@@ -338,15 +335,15 @@ final class ElasticsearchQueryCodableTests: XCTestCase {
         let fuzzy = Fuzzy(field: "name", value: "bolster", fuzziness: 2)
         let query = Query(fuzzy)
         let encoded = try encoder.encodeToString(query)
-        
+
         XCTAssertEqual(json, encoded)
-        
+
         let toDecode = try encoder.encode(query)
         let decoded = try decoder.decode(Query.self, from: toDecode)
         let encodedAgain = try encoder.encodeToString(decoded)
         XCTAssertEqual(json, encodedAgain)
     }
-    
+
     func testIDs_encodesInQueryCorrectly() throws {
         let json = """
         {"ids":{"values":["1","2","3"]}}
@@ -354,101 +351,130 @@ final class ElasticsearchQueryCodableTests: XCTestCase {
         let ids = IDs(["1", "2", "3"])
         let query = Query(ids)
         let encoded = try encoder.encodeToString(query)
-        
+
         XCTAssertEqual(json, encoded)
-        
+
         let toDecode = try encoder.encode(query)
         let decoded = try decoder.decode(Query.self, from: toDecode)
         let encodedAgain = try encoder.encodeToString(decoded)
         XCTAssertEqual(json, encodedAgain)
     }
-    
+
     func testSpanFirst_encodesInQueryCorrectly() throws {
         let json =  """
         {"span_first":{"match":{"span_term":{"user":{"term":"kimchy"}}},"end":3}}
         """
-        
+
         let span  = SpanFirst(match: SpanTerm(field: "user", term: "kimchy"), end: 3)
         let query = Query(span)
         let encoded = try encoder.encodeToString(query)
-        
+
         XCTAssertEqual(json, encoded)
-        
+
         let toDecode = try encoder.encode(query)
         let decoded = try decoder.decode(Query.self, from: toDecode)
         let encodedAgain = try encoder.encodeToString(decoded)
         XCTAssertEqual(json, encodedAgain)
     }
-    
+
     func testSpanNot_encodesInQueryCorrectly() throws {
         let json =  """
         {"span_not":{"include":{"span_term":{"user":{"term":"kimchy"}}},"exclude":{"span_term":{"user":{"term":"yhcmik"}}},"pre":3}}
         """
-        
+
         let span  = SpanNot(include: SpanTerm(field: "user", term: "kimchy"), exclude: SpanTerm(field: "user", term: "yhcmik"), pre: 3)
         let query = Query(span)
         let encoded = try encoder.encodeToString(query)
-        
+
         XCTAssertEqual(json, encoded)
-        
+
         let toDecode = try encoder.encode(query)
         let decoded = try decoder.decode(Query.self, from: toDecode)
         let encodedAgain = try encoder.encodeToString(decoded)
         XCTAssertEqual(json, encodedAgain)
     }
-    
+
     func testSpanOr_encodesInQueryCorrectly() throws {
         let json =  """
         {"span_or":{"clauses":[{"span_term":{"field":{"term":"value1"}}},{"span_term":{"field":{"term":"value2"}}}]}}
         """
-        
+
         let span  = SpanOr([SpanTerm(field: "field", term: "value1"), SpanTerm(field: "field", term: "value2")])
         let query = Query(span)
         let encoded = try encoder.encodeToString(query)
-        
+
         XCTAssertEqual(json, encoded)
-        
+
         let toDecode = try encoder.encode(query)
         let decoded = try decoder.decode(Query.self, from: toDecode)
         let encodedAgain = try encoder.encodeToString(decoded)
         XCTAssertEqual(json, encodedAgain)
     }
-    
+
     func testSpanNear_encodesInQueryCorrectly() throws {
         let json =  """
         {"span_near":{"clauses":[{"span_term":{"field":{"term":"value1"}}},{"span_term":{"field":{"term":"value2"}}}],"slop":10}}
         """
-        
+
         let span  = SpanNear([SpanTerm(field: "field", term: "value1"), SpanTerm(field: "field", term: "value2")], slop: 10)
         let query = Query(span)
         let encoded = try encoder.encodeToString(query)
-        
+
         XCTAssertEqual(json, encoded)
-        
+
         let toDecode = try encoder.encode(query)
         let decoded = try decoder.decode(Query.self, from: toDecode)
         let encodedAgain = try encoder.encodeToString(decoded)
         XCTAssertEqual(json, encodedAgain)
     }
-    
+
     func testGeoPolygon_encodesInQueryCorrectly() throws {
         let json =  """
         {"geo_polygon":{"person.location":{"points":[{"lat":40,"lon":-70},{"lat":30,"lon":-80},{"lat":20,"lon":-90}]}}}
         """
-        
+
         let poly  = GeoPolygon(field: "person.location", points: [GeoPoint(lat: 40, lon: -70), GeoPoint(lat: 30, lon: -80), GeoPoint(lat: 20, lon: -90)])
         let query = Query(poly)
         let encoded = try encoder.encodeToString(query)
-        
+
         XCTAssertEqual(json, encoded)
-        
+
         let toDecode = try encoder.encode(query)
         let decoded = try decoder.decode(Query.self, from: toDecode)
         let encodedAgain = try encoder.encodeToString(decoded)
         XCTAssertEqual(json, encodedAgain)
     }
-    
-    
+
+    func testSort_encodesInQueryCorrectly() throws {
+        let json = """
+        {"recipe_name":{"order":"desc"}}
+        """
+
+        let sort = Sort("recipe_name", .descending)
+        let encoded = try encoder.encodeToString(sort)
+
+        XCTAssertEqual(json, encoded)
+
+        let toDecode = try encoder.encode(sort)
+        let decoded = try decoder.decode(Sort.self, from: toDecode)
+        let encodedAgain = try encoder.encodeToString(decoded)
+        XCTAssertEqual(json, encodedAgain)
+    }
+
+    func testSort_encodesInSearchContainerCorrectly() throws {
+        let json = """
+        {"size":10,"query":{"match_all":{}},"sort":[{"recipe_name":{"order":"desc"}}],"from":0}
+        """
+
+        let matchAll = MatchAll()
+        let sort = Sort("recipe_name", .descending)
+        let query = Query(matchAll)
+        let container = SearchContainer(query, sort: [sort])
+        let encoded = try encoder.encodeToString(container)
+
+        XCTAssertEqual(json, encoded)
+    }
+
     func testLinuxTestSuiteIncludesAllTests() {
         #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
         let thisClass = type(of: self)
@@ -457,18 +483,18 @@ final class ElasticsearchQueryCodableTests: XCTestCase {
         XCTAssertEqual(linuxCount, darwinCount, "\(darwinCount - linuxCount) tests are missing from allTests")
         #endif
     }
-    
+
     static var allTests = [
         ("testAvgAggregation_encodesCorrectly",     testAvgAggregation_encodesCorrectly),
         ("testCardinalityAggregation_encodesCorrectly", testCardinalityAggregation_encodesCorrectly),
         ("testExtendedStatsAggregation_encodesCorrectly", testExtendedStatsAggregation_encodesCorrectly),
         ("testGeoBoundsAggregation_encodesCorrectly", testGeoBoundsAggregation_encodesCorrectly),
         ("testGeoCentroidAggregation_encodesCorrectly", testGeoCentroidAggregation_encodesCorrectly),
-        ("testMaxAggregation_encodesCorrectly", testMaxAggregation_encodesCorrectly),
-        ("testMinAggregation_encodesCorrectly", testMinAggregation_encodesCorrectly),
-        ("testTermsAggregation_encodesCorrectly", testTermsAggregation_encodesCorrectly),
+        ("testMaxAggregation_encodesCorrectly",     testMaxAggregation_encodesCorrectly),
+        ("testMinAggregation_encodesCorrectly",     testMinAggregation_encodesCorrectly),
+        ("testTermsAggregation_encodesCorrectly",   testTermsAggregation_encodesCorrectly),
         ("testQueryContainer_encodesCorrectly",     testQueryContainer_encodesCorrectly),
-        
+
         ("testMatchAll_encodesInQueryCorrectly",    testMatchAll_encodesInQueryCorrectly),
         ("testMatchNone_encodesInQueryCorrectly",   testMatchNone_encodesInQueryCorrectly),
         ("testMatch_encodesInQueryCorrectly",       testMatch_encodesInQueryCorrectly),
@@ -476,10 +502,10 @@ final class ElasticsearchQueryCodableTests: XCTestCase {
         ("testMultiMatch_encodesInQueryCorrectly",  testMultiMatch_encodesInQueryCorrectly),
         ("testTerm_encodesInQueryCorrectly",        testTerm_encodesInQueryCorrectly),
         ("testTerms_encodesInQueryCorrectly",       testTerms_encodesInQueryCorrectly),
-        
+
         ("testRange_encodesInQueryCorrectly",       testRange_encodesInQueryCorrectly),
         ("testRange_encodesInQueryCorrectly_date",  testRange_encodesInQueryCorrectly_date),
-        
+
         ("testExists_encodesInQueryCorrectly",      testExists_encodesInQueryCorrectly),
         ("testBool_encodesInQueryCorrectly",        testBool_encodesInQueryCorrectly),
         ("testPrefix_encodesInQueryCorrectly",      testPrefix_encodesInQueryCorrectly),
@@ -492,7 +518,9 @@ final class ElasticsearchQueryCodableTests: XCTestCase {
         ("testSpanOr_encodesInQueryCorrectly",      testSpanOr_encodesInQueryCorrectly),
         ("testSpanNear_encodesInQueryCorrectly",    testSpanNear_encodesInQueryCorrectly),
         ("testGeoPolygon_encodesInQueryCorrectly",  testGeoPolygon_encodesInQueryCorrectly),
-        
+
+        ("testSort_encodesInQueryCorrectly",        testSort_encodesInQueryCorrectly),
+
         ("testLinuxTestSuiteIncludesAllTests",      testLinuxTestSuiteIncludesAllTests)
     ]
 }


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! --->

<!-- Provide a brief description of the PR here. -->
<!-- Pretend you are explaining it to a friend, not yourself! -->

This PR adds a very trivial implementation of specifying custom search order. New tests have been added and existing tests didn’t require any modification, thus implicating that no major changes were performed.

The only thing I had to adjust is to make the `score` field in `SearchResponse` optional, as supplying custom search order prevents Elasticsearch to calculate the score for you. I’m hoping that the added benefits of this PR justify the change.

### Checklist

<!-- The items on this checklist must be completed to merge. -->

- [x] All tests are passing (code compiles and passes tests).
- [ ] There are no breaking changes to public API.
  - No, `score` field in `SearchResponse` was made optional
- [x] New test cases have been added where appropriate.
- [ ] All new code has been commented with doc blocks `///`.
  - No, most (all?) of the new code is trivial enough.

Thank you for consideration! 🙇 
