### PR TITLE
Implemented search suggestions

### DIFF
--- a/Sources/Elasticsearch/Client/ElasticsearchClient+Suggest.swift
+++ b/Sources/Elasticsearch/Client/ElasticsearchClient+Suggest.swift
@@ -1,0 +1,39 @@
+import HTTP
+
+/**
+ Suggest methods.
+ */
+extension ElasticsearchClient {
+    /// Execute a suggest search in a given index
+    ///
+    /// - Parameters:
+    ///   - index: The index to execute the query against
+    ///   - query: A SearchContainer object that specifies the query to execute
+    ///   - type: The index type (defaults to _doc)
+    ///   - routing: Routing information
+    /// - Returns: A Future SearchResponse
+    public func suggest(
+        index: String,
+        query: SuggestContainer,
+        type: String = "_doc",
+        routing: String? = nil
+    ) -> Future<SuggestResponse> {
+        let body: Data
+        do {
+            body = try self.encoder.encode(query)
+        } catch {
+            return worker.future(error: error)
+        }
+        let url = ElasticsearchClient.generateURL(path: "/\(index)/\(type)/_search", routing: routing)
+
+        return send(HTTPMethod.POST, to: url.string!, with: body).map { jsonData in
+            let decoder = JSONDecoder()
+
+            if let jsonData = jsonData {
+                return try decoder.decode(SuggestResponse.self, from: jsonData)
+            }
+
+            throw ElasticsearchError(identifier: "search_failed", reason: "Could not execute suggest", source: .capture(), statusCode: 404)
+        }
+    }
+}

--- a/Sources/Elasticsearch/Model/Response/SuggestResponse.swift
+++ b/Sources/Elasticsearch/Model/Response/SuggestResponse.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+public struct SuggestResponse: Decodable {
+    public let took: Int
+    public let timedOut: Bool
+    public let shards: Shards
+    public let hits: HitsContainer?
+    public let suggest: [String: [SuggestResult]]
+
+    public var suggestions: [String] {
+        return suggest.values
+            .flatMap { $0 }
+            .flatMap { $0.options }
+            .compactMap { $0.text }
+    }
+
+    public struct Shards: Decodable {
+        public let total: Int
+        public let successful: Int
+        public let skipped: Int
+        public let failed: Int
+    }
+
+    public struct HitsContainer: Decodable {
+        public let total: Int
+        public let maxScore: Decimal?
+    }
+
+    public struct SuggestResult: Decodable {
+        public let text: String
+        public let offset: Int
+        public let length: Int
+        public let options: [SuggestOption]
+    }
+
+    public struct SuggestOption: Decodable {
+        public let id: String
+        public let text: String
+
+        enum CodingKeys: String, CodingKey {
+            case id = "_id"
+            case text
+        }
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case took
+        case timedOut = "timed_out"
+        case shards = "_shards"
+        case hits
+        case suggest
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        self.took = try container.decode(Int.self, forKey: .took)
+        self.timedOut = try container.decode(Bool.self, forKey: .timedOut)
+        self.shards = try container.decode(Shards.self, forKey: .shards)
+        self.hits = try container.decode(HitsContainer.self, forKey: .hits)
+        self.suggest = try container.decode([String: [SuggestResult]].self, forKey: .suggest)
+    }
+}

--- a/Sources/Elasticsearch/Search/Query/Suggest.swift
+++ b/Sources/Elasticsearch/Search/Query/Suggest.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+public struct Suggest: Encodable {
+    public let name: String
+    public let prefix: String
+    public let field: String
+
+    public init(name: String, prefix: String, field: String) {
+        self.name = name
+        self.prefix = prefix
+        self.field = field
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        var completion = container.nestedContainer(keyedBy: CompletionKeys.self, forKey: .completion)
+
+        try container.encode(prefix, forKey: .prefix)
+        try completion.encode(field, forKey: .field)
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case prefix
+        case completion
+    }
+
+    enum CompletionKeys: String, CodingKey {
+        case field
+    }
+}

--- a/Sources/Elasticsearch/Search/SuggestContainer.swift
+++ b/Sources/Elasticsearch/Search/SuggestContainer.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+public struct SuggestContainer: Encodable {
+    public let suggests: [Suggest]
+
+    public init(suggests: [Suggest]) {
+        self.suggests = suggests
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        var suggestNode = container.nestedContainer(keyedBy: DynamicKey.self, forKey: .suggest)
+
+        try suggests.forEach { suggest in
+            try suggestNode.encode(suggest, forKey: DynamicKey(stringValue: suggest.name)!)
+        }
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case suggest
+    }
+}


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! --->

This PR adds a basic implementation of search suggestions. It doesn’t attempt to decode the suggested objects as that’s often not needed, it simply returns the suggestions returned by Elasticsearch. Perhaps another method that would take a `decodeTo` generic argument could be added later if people need it.

A convenience method that collects all returned suggestions and returns them as an `[String]` was also added, as that seems like something that might be helpful.

<!-- Provide a brief description of the PR here. -->
<!-- Pretend you are explaining it to a friend, not yourself! -->

### Checklist

<!-- The items on this checklist must be completed to merge. -->

- [x] All tests are passing (code compiles and passes tests).
- [x] There are no breaking changes to public API.
- [ ] New test cases have been added where appropriate.
- [ ] All new code has been commented with doc blocks `///`.
