### PR TITLE
Function score query

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/vapor/console.git",
         "state": {
           "branch": null,
-          "revision": "5b9796d39f201b3dd06800437abd9d774a455e57",
-          "version": "3.0.2"
+          "revision": "d6cf07af59ae63cd95c4b5f98cf1f25627750fd1",
+          "version": "3.1.0"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/vapor/core.git",
         "state": {
           "branch": null,
-          "revision": "7f56a09995bf3c8df562be456bdcda405d9d0678",
-          "version": "3.4.1"
+          "revision": "96ce86ebf9198328795c4b9cb711489460be083c",
+          "version": "3.4.4"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/vapor/crypto.git",
         "state": {
           "branch": null,
-          "revision": "4b85405430df1892ee3aa1554bdb477e96cf46ad",
-          "version": "3.2.0"
+          "revision": "5605334590affd4785a5839806b4504407e054ac",
+          "version": "3.3.0"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/vapor/database-kit.git",
         "state": {
           "branch": null,
-          "revision": "7a01659316b9f033fa2150d5cd5e9d3c3e46c2e3",
-          "version": "1.3.0"
+          "revision": "3a17dbbe9be5f8c37703e4b7982c1332ad6b00c4",
+          "version": "1.3.1"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/vapor/http.git",
         "state": {
           "branch": null,
-          "revision": "8123ea00e9858b369cd168d0303d33e7d3804d19",
-          "version": "3.0.7"
+          "revision": "6973bf50dab8dd00e4daf8cb82ca72b33f5db016",
+          "version": "3.1.6"
         }
       },
       {
@@ -78,8 +78,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "695afc5205aaa49fca092b94b479ff71c43d9d3c",
-          "version": "1.8.0"
+          "revision": "a20e129c22ad00a51c902dca54a5456f90664780",
+          "version": "1.12.0"
         }
       },
       {
@@ -87,8 +87,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-ssl.git",
         "state": {
           "branch": null,
-          "revision": "6617eb0d3afcb12170594968df01ca63afb58ac5",
-          "version": "1.2.0"
+          "revision": "db16c3a90b101bb53b26a58867a344ad428072e0",
+          "version": "1.3.2"
         }
       },
       {
@@ -114,8 +114,8 @@
         "repositoryURL": "https://github.com/vapor/template-kit.git",
         "state": {
           "branch": null,
-          "revision": "43b57b5861d5181b906ac6411d28645e980bb638",
-          "version": "1.0.1"
+          "revision": "aff2d6fc65bfd04579b0201b31a8d6720239c1cf",
+          "version": "1.1.1"
         }
       },
       {
@@ -123,8 +123,8 @@
         "repositoryURL": "https://github.com/vapor/url-encoded-form.git",
         "state": {
           "branch": null,
-          "revision": "cbfe7ef6301557d3f2d0807a98165232ae06e1c6",
-          "version": "1.0.4"
+          "revision": "932024f363ee5ff59059cf7d67194a1c271d3d0c",
+          "version": "1.0.5"
         }
       },
       {
@@ -132,8 +132,8 @@
         "repositoryURL": "https://github.com/vapor/validation.git",
         "state": {
           "branch": null,
-          "revision": "ab6c5a352d97c8687b91ed4963aef8e7cfe0795b",
-          "version": "2.0.0"
+          "revision": "4de213cf319b694e4ce19e5339592601d4dd3ff6",
+          "version": "2.1.1"
         }
       },
       {
@@ -141,8 +141,8 @@
         "repositoryURL": "https://github.com/vapor/vapor.git",
         "state": {
           "branch": null,
-          "revision": "54632a6c1e7ecd9923c0d00b612de936de1c4745",
-          "version": "3.0.8"
+          "revision": "157d3b15336caa882662cc75024dd04b2e225246",
+          "version": "3.1.0"
         }
       },
       {
@@ -150,8 +150,8 @@
         "repositoryURL": "https://github.com/vapor/websocket.git",
         "state": {
           "branch": null,
-          "revision": "141cb4d3814dc8062cb0b2f43e72801b5dfcf272",
-          "version": "1.0.1"
+          "revision": "eb4277f75f1d96a3d15c852cdd89af1799093dcd",
+          "version": "1.1.0"
         }
       }
     ]

--- a/Sources/Elasticsearch/Search/Query/AnyQuery.swift
+++ b/Sources/Elasticsearch/Search/Query/AnyQuery.swift
@@ -4,6 +4,7 @@ public enum QueryElementMap : String, Codable {
     case boolQuery = "bool"
     case exists
     case fuzzy
+    case functionScore = "function_score"
     case ids
     case match
     case matchAll = "match_all"
@@ -36,6 +37,8 @@ public enum QueryElementMap : String, Codable {
             return Exists.self
         case .fuzzy:
             return Fuzzy.self
+        case .functionScore:
+            return FunctionScore.self
         case .ids:
             return IDs.self
         case .match:

--- a/Sources/Elasticsearch/Search/Query/FunctionScore.swift
+++ b/Sources/Elasticsearch/Search/Query/FunctionScore.swift
@@ -1,0 +1,75 @@
+//
+//  FunctionScoreQuery.swift
+//  Async
+//
+//  Created by Kelly Bennett on 1/4/19.
+//
+
+import Foundation
+
+/**
+ The `Function Score` returns documents in "score" order, as determined by the score funtions.
+ 
+ [More information](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-function-score-query.html)
+ */
+
+public struct FunctionScore: QueryElement {
+    /// :nodoc:
+    public static var typeKey = QueryElementMap.functionScore
+    
+    public let query: QueryElement
+    public let boost: Decimal?
+    public let functions: [ScoreFunctionElement]
+    public let maxBoost: Decimal?
+    public let scoreMode: String?
+    public let boostMode: String?
+    public let minScore: Decimal?
+    
+    public init(query: QueryElement,
+                boost: Decimal? = nil,
+                functions: [ScoreFunctionElement],
+                maxBoost: Decimal? = nil,
+                scoreMode: String? = nil,
+                boostMode: String? = nil,
+                minScore: Decimal? = nil) {
+        self.query = query
+        self.boost = boost
+        self.functions = functions
+        self.maxBoost = maxBoost
+        self.scoreMode = scoreMode
+        self.boostMode = boostMode
+        self.minScore = minScore
+    }
+    
+    private enum CodingKeys: String, CodingKey {
+        case query
+        case boost
+        case functions
+        case maxBoost = "max_boost"
+        case scoreMode = "score_mode"
+        case boostMode = "boost_mode"
+        case minScore = "min_score"
+    }
+    
+    
+    /// :nodoc:
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(boost, forKey: .boost)
+        try container.encodeIfPresent(maxBoost, forKey: .maxBoost)
+        try container.encodeIfPresent(scoreMode, forKey: .scoreMode)
+    }
+    
+    /// :nodoc:
+    public init(from decoder: Decoder) throws {
+        //        TODO: get these from the decoder
+        self.query = MatchAll()
+        self.boost = nil
+        self.functions = [RandomScore()]
+        self.maxBoost = nil
+        self.scoreMode = nil
+        self.boostMode = "sum"
+        self.minScore = nil
+        
+    }
+}

--- a/Sources/Elasticsearch/Search/Query/Score Functions/AnyScoreFunction.swift
+++ b/Sources/Elasticsearch/Search/Query/Score Functions/AnyScoreFunction.swift
@@ -1,0 +1,59 @@
+//
+//  AnyScoreFunction.swift
+//  Async
+//
+//  Created by Kelly Bennett on 1/4/19.
+//
+
+import Foundation
+/// :nodoc:
+public enum ScoreFunctionMap : String, Codable {
+    
+    case scriptScore = "script_score"
+    case weight
+    case randomScore = "random_score"
+    case fieldValueFactor = "field_value_factor"
+    case guass
+    case linear
+    case exp
+    
+    var metatype: ScoreFunction.Type {
+        switch self {
+        case .scriptScore:
+            return ScriptScore.self
+        case .weight:
+            return WeightScore.self
+        case .randomScore:
+            return RandomScore.self
+        case .fieldValueFactor:
+            return FieldValueFactor.self
+        case .guass:
+            return Guass.self
+        case .linear:
+            return Linear.self
+        case .exp:
+            return Exp.self
+        }
+    }
+}
+
+internal struct AnyScoreFunctionElement : Codable {
+    public var base: ScoreFunctionElement
+    
+    init(_ base: ScoreFunctionElement) {
+        self.base = base
+    }
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: DynamicKey.self)
+        let key = container.allKeys.first
+        let type = ScoreFunctionMap(rawValue: key!.stringValue)!
+        let innerDecoder = try container.superDecoder(forKey: key!)
+        self.base = try type.metatype.init(from: innerDecoder)
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        try base.encode(to: encoder)
+    }
+}
+

--- a/Sources/Elasticsearch/Search/Query/Score Functions/AnyScoreFunction.swift
+++ b/Sources/Elasticsearch/Search/Query/Score Functions/AnyScoreFunction.swift
@@ -17,7 +17,7 @@ public enum ScoreFunctionMap : String, Codable {
     case linear
     case exp
     
-    var metatype: ScoreFunction.Type {
+    var metatype: ScoreFunctionElement.Type {
         switch self {
         case .scriptScore:
             return ScriptScore.self

--- a/Sources/Elasticsearch/Search/Query/Score Functions/Exp.swift
+++ b/Sources/Elasticsearch/Search/Query/Score Functions/Exp.swift
@@ -1,0 +1,25 @@
+//
+//  Exp.swift
+//  Async
+//
+//  Created by Kelly Bennett on 1/4/19.
+//
+
+import Foundation
+
+public struct Exp: ScoreFunctionElement {
+    public static var typeKey = ScoreFunctionMap.exp
+    
+    //    TODO: implement the rest of this
+    public init() {
+        
+    }
+    
+    /// :nodoc:
+    public func encode(to encoder: Encoder) throws {}
+    
+    /// :nodoc:
+    public init(from decoder: Decoder) throws {
+        //TODO: get from decoder
+    }
+}

--- a/Sources/Elasticsearch/Search/Query/Score Functions/FieldValueFactor.swift
+++ b/Sources/Elasticsearch/Search/Query/Score Functions/FieldValueFactor.swift
@@ -1,0 +1,27 @@
+//
+//  FieldValueFactor.swift
+//  Async
+//
+//  Created by Kelly Bennett on 1/4/19.
+//
+
+import Foundation
+
+public struct FieldValueScore: ScoreFunctionElement {
+    public static var typeKey = ScoreFunctionMap.fieldValueFactor
+    
+    public let field: String
+    
+    public init(field: String) {
+        self.field = field
+    }
+    
+    /// :nodoc:
+    public func encode(to encoder: Encoder) throws {}
+    
+    /// :nodoc:
+    public init(from decoder: Decoder) throws {
+        //TODO: get from decoder
+        self.field = "taco"
+    }
+}

--- a/Sources/Elasticsearch/Search/Query/Score Functions/FieldValueFactor.swift
+++ b/Sources/Elasticsearch/Search/Query/Score Functions/FieldValueFactor.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct FieldValueScore: ScoreFunctionElement {
+public struct FieldValueFactor: ScoreFunctionElement {
     public static var typeKey = ScoreFunctionMap.fieldValueFactor
     
     public let field: String

--- a/Sources/Elasticsearch/Search/Query/Score Functions/Guass.swift
+++ b/Sources/Elasticsearch/Search/Query/Score Functions/Guass.swift
@@ -1,0 +1,25 @@
+//
+//  Guass.swift
+//  Async
+//
+//  Created by Kelly Bennett on 1/4/19.
+//
+
+import Foundation
+
+public struct Guass: ScoreFunctionElement {
+    public static var typeKey = ScoreFunctionMap.guass
+    
+    //    TODO: implement the rest of this
+    public init() {
+
+    }
+    
+    /// :nodoc:
+    public func encode(to encoder: Encoder) throws {}
+    
+    /// :nodoc:
+    public init(from decoder: Decoder) throws {
+        //TODO: get from decoder
+    }
+}

--- a/Sources/Elasticsearch/Search/Query/Score Functions/Linear.swift
+++ b/Sources/Elasticsearch/Search/Query/Score Functions/Linear.swift
@@ -1,0 +1,25 @@
+//
+//  Linear.swift
+//  Async
+//
+//  Created by Kelly Bennett on 1/4/19.
+//
+
+import Foundation
+
+public struct Linear: ScoreFunctionElement {
+    public static var typeKey = ScoreFunctionMap.linear
+    
+    //    TODO: implement the rest of this
+    public init() {
+        
+    }
+    
+    /// :nodoc:
+    public func encode(to encoder: Encoder) throws {}
+    
+    /// :nodoc:
+    public init(from decoder: Decoder) throws {
+        //TODO: get from decoder
+    }
+}

--- a/Sources/Elasticsearch/Search/Query/Score Functions/RandomScore.swift
+++ b/Sources/Elasticsearch/Search/Query/Score Functions/RandomScore.swift
@@ -1,0 +1,21 @@
+//
+//  Random.swift
+//  Async
+//
+//  Created by Kelly Bennett on 1/4/19.
+//
+
+import Foundation
+
+public struct RandomScore: ScoreFunctionElement {
+    public static var typeKey = ScoreFunctionMap.randomScore
+    
+    public init() {
+    }
+    
+    /// :nodoc:
+    public func encode(to encoder: Encoder) throws {}
+    
+    /// :nodoc:
+    public init(from decoder: Decoder) throws {}
+}

--- a/Sources/Elasticsearch/Search/Query/Score Functions/ScoreFunction.swift
+++ b/Sources/Elasticsearch/Search/Query/Score Functions/ScoreFunction.swift
@@ -1,0 +1,42 @@
+//
+//  ScoreFunction.swift
+//  Async
+//
+//  Created by Kelly Bennett on 1/4/19.
+//
+
+import Foundation
+
+/// :nodoc:
+public protocol ScoreFunctionElement: Codable {
+    static var typeKey: ScoreFunctionMap { get }
+}
+
+public struct ScoreFunction: Codable {
+    public let function: ScoreFunctionElement
+    
+    enum CodingKeys: String, CodingKey {
+        case function
+    }
+    
+    public init(_ function: ScoreFunctionElement) {
+        self.function = function
+    }
+    
+    /// :nodoc:
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: DynamicKey.self)
+        
+        try container.encode(AnyScoreFunctionElement(function), forKey: DynamicKey(stringValue: type(of: function).typeKey.rawValue)!)
+    }
+    
+    /// :nodoc:
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: DynamicKey.self)
+        let key = container.allKeys.first
+        let type = ScoreFunctionMap(rawValue: key!.stringValue)!
+        let innerDecoder = try container.superDecoder(forKey: key!)
+        self.function = try type.metatype.init(from: innerDecoder)
+    }
+}
+

--- a/Sources/Elasticsearch/Search/Query/Score Functions/ScriptScore.swift
+++ b/Sources/Elasticsearch/Search/Query/Score Functions/ScriptScore.swift
@@ -1,0 +1,27 @@
+//
+//  ScoreFunction.swift
+//  Async
+//
+//  Created by Kelly Bennett on 1/4/19.
+//
+
+import Foundation
+
+public struct ScriptScore: ScoreFunctionElement {
+    public static var typeKey = ScoreFunctionMap.scriptScore
+    
+    public let script: String
+    
+    public init(script: String) {
+        self.script = script
+    }
+    
+    /// :nodoc:
+    public func encode(to encoder: Encoder) throws {}
+    
+    /// :nodoc:
+    public init(from decoder: Decoder) throws {
+        //TODO: get from decoder
+        self.script = ""
+    }
+}

--- a/Sources/Elasticsearch/Search/Query/Score Functions/ScriptScore.swift
+++ b/Sources/Elasticsearch/Search/Query/Score Functions/ScriptScore.swift
@@ -10,18 +10,25 @@ import Foundation
 public struct ScriptScore: ScoreFunctionElement {
     public static var typeKey = ScoreFunctionMap.scriptScore
     
-    public let script: String
+    public let script: Script
     
-    public init(script: String) {
+    public init(script: Script) {
         self.script = script
     }
     
+    enum CodingKeys: String, CodingKey {
+        case script
+    }
+    
     /// :nodoc:
-    public func encode(to encoder: Encoder) throws {}
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(script, forKey: .script)
+    }
     
     /// :nodoc:
     public init(from decoder: Decoder) throws {
-        //TODO: get from decoder
-        self.script = ""
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.script = try container.decode(Script.self, forKey: .script)
     }
 }

--- a/Sources/Elasticsearch/Search/Query/Score Functions/WeightScore.swift
+++ b/Sources/Elasticsearch/Search/Query/Score Functions/WeightScore.swift
@@ -1,0 +1,28 @@
+//
+//  Weight.swift
+//  Async
+//
+//  Created by Kelly Bennett on 1/4/19.
+//
+
+import Foundation
+
+public struct WeightScore: ScoreFunctionElement {
+    public static var typeKey = ScoreFunctionMap.weight
+    
+    public let weight: Decimal
+    
+    public init(weight: Decimal) {
+        self.weight = weight
+    }
+    
+    /// :nodoc:
+    public func encode(to encoder: Encoder) throws {}
+    
+    /// :nodoc:
+    public init(from decoder: Decoder) throws {
+        //TODO: get from decoder
+        self.weight = 1
+    }
+}
+

--- a/Tests/ElasticsearchTests/ElasticsearchQueryCodableTests.swift
+++ b/Tests/ElasticsearchTests/ElasticsearchQueryCodableTests.swift
@@ -101,7 +101,33 @@ final class ElasticsearchQueryCodableTests: XCTestCase {
 
         XCTAssertEqual(json, encoded)
     }
+    
+    func testFunctionScoreQuery_withScriptScore_encodesInQueryCorrectly() throws {
+        let json = """
+        {"function_score":{"functions":[{"script_score":{"script":{"lang":"painless","source":"_score * doc['id'].value"}}}],"query":{"match_all":{}},"score_mode":"sum","boost":10,"max_boost":100}}
+        """
+        let script = Script(lang: "painless", source: "_score * doc['id'].value")
+        let functionScore = FunctionScore(
+            query: MatchAll(),
+            boost: 10,
+            functions: [ScriptScore(script: script)],
+            maxBoost: 100,
+            scoreMode: "sum",
+            boostMode: "multiply",
+            minScore: 1)
+        let query = Query(functionScore)
+        let encoded = try encoder.encodeToString(query)
+        
+        XCTAssertEqual(json, encoded)
+        
+        let toDecode = try encoder.encode(query)
+        let decoded = try decoder.decode(Query.self, from: toDecode)
+        let encodedAgain = try encoder.encodeToString(decoded)
 
+        XCTAssertEqual(json, encodedAgain)
+    }
+        
+        
     func testMatchAll_encodesInQueryCorrectly() throws {
         let json = """
         {"match_all":{}}


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! --->

This adds [function score query](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-function-score-query.html) support

### Checklist

<!-- The items on this checklist must be completed to merge. -->

- [x] All tests are passing (code compiles and passes tests).
- [x] There are no breaking changes to public API.
- [x] New test cases have been added where appropriate.
- [x] All new code has been commented with doc blocks `///`.

### Not that not all score functions are fully filled out. These will come later. For now, script_score is the only functional score function.