### PR TITLE
Added fuzziness support to Multi Match

### DIFF
--- a/Sources/Elasticsearch/Search/Query/MultiMatch.swift
+++ b/Sources/Elasticsearch/Search/Query/MultiMatch.swift
@@ -12,17 +12,20 @@ public struct MultiMatch: QueryElement {
     public let value: String
     public let fields: [String]
     public let type: Kind?
+    public let fuzziness: Int?
     public let tieBreaker: Decimal?
 
     public init(
         value: String,
         fields: [String],
         type: Kind? = nil,
+        fuzziness: Int? = nil,
         tieBreaker: Decimal? = nil
     ) {
         self.value = value
         self.fields = fields
         self.type = type
+        self.fuzziness = fuzziness
         self.tieBreaker = tieBreaker
     }
 
@@ -38,6 +41,7 @@ public struct MultiMatch: QueryElement {
         case value = "query"
         case fields
         case type
+        case fuzziness
         case tieBreaker = "tie_breaker"
     }
 }


### PR DESCRIPTION
This PR adds support for the fuzzyness property in multi match query. The implementation is just the same like in the normal match query.

### Checklist

<!-- The items on this checklist must be completed to merge. -->

- [x] All tests are passing (code compiles and passes tests).
- [x] There are no breaking changes to public API.
- [ ] New test cases have been added where appropriate.
- [ ] All new code has been commented with doc blocks.
